### PR TITLE
CSS 커스터마이징 기능 추가

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,7 +6,20 @@ module.exports = {
   webpackFinal: async config => {
     config.module.rules.push({
       test: /\.scss$/,
-      use: ['style-loader', 'css-loader', 'sass-loader'],
+      use: [
+        { loader: 'style-loader' },
+        { loader: 'css-loader' },
+        {
+          loader: 'sass-loader',
+          options: {
+            sourceMap: true,
+            additionalData: '@import "variables";',
+            sassOptions: {
+              includePaths: [path.resolve(__dirname, '../src')],
+            },
+          },
+        },
+      ],
       include: path.resolve(__dirname, '../'),
     });
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ const player = new BetterPlayer.Player(options);
 
 **iconUrl: string**
 
-아이콘 svg sprite를 별도 제공하고 싶은 경우, sprite url을 직접 입력합니다. 자세한 내용은 [Customizing](#Customizing)을 참고 하세요.
+아이콘 svg sprite를 별도 제공하고 싶은 경우, sprite url을 직접 입력합니다. 자세한 내용은 [Customizing](#아이콘-별도로-제공하기)을 참고 하세요.
 
 ## API
 
@@ -312,6 +312,41 @@ player.on('play', event => {
 
 다양한 방식으로 비디오 플레이어의 스타일을 변경할 수 있습니다.
 
+### CSS 스타일링 하기
+
+기본으로 제공되는 UI 스타일을 CSS custom properties를 이용해서 변경할 수 있습니다. CSS custom properties에 대해 자세히 알고 싶다면 [다음](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)을 참고하세요.
+
+BetterPlayer에서 제공하는 CSS custom properties 목록은 다음과 같습니다.
+
+| 이름                                      | 설명                          | 기본값                             |
+| ----------------------------------------- | ----------------------------- | ---------------------------------- |
+| `--better-player-color-main`              | 비디오 플레이어의 메인 색상   | #fff                               |
+| `--better-player-font-size`               | 비디오 플레이어의 폰트 사이즈 | 16px                               |
+| `--better-player-font-color`              | 비디오 플레이어의 폰트 색상   | #fff                               |
+| `--better-player-controller-background`   | 컨트롤러의 배경 색상          | linear-gradient(transparent, #000) |
+| `--better-player-controller-spacing`      | 컨트롤러 유닛 간의 간격       | 5px                                |
+| `--better-player-controller-icon-size`    | 컨트롤러 아이콘 크기          | 32px                               |
+| `--better-player-controller-font-size`    | 컨트롤러 폰트 크기            | 15px                               |
+| `--better-player-controller-color`        | 컨트롤러 아이콘 및 폰트 색상  | #fff                               |
+| `--better-player-error-screen-icon-size`  | 에러 스크린의 아이콘 크기     | 36px                               |
+| `--better-player-error-screen-icon-color` | 에러 스크린의 아이콘 색상     | #fff                               |
+
+웹 페이지의 모든 플레이어에 적용하고 싶다면 다음과 같이 사용하세요.
+
+```css
+:root {
+  --better-player-color-main: #f0f;
+}
+```
+
+하나의 플레이어의 스타일을 변경하기 위해 다음과 같이 css selector를 이용할 수도 있습니다.
+
+```css
+.player {
+  --better-player-color-main: #f0f;
+}
+```
+
 ### 아이콘 별도로 제공하기
 
 BetterPlayer는 svg 아이콘을 사용하고 있습니다. 만약 자신만의 멋진 아이콘들이 svg 파일로 준비되어 있다면 옵션 객체의 `iconUrl` 속성을 이용해서 내 아이콘을 비디오 플레이어에 적용할 수 있습니다.
@@ -335,7 +370,7 @@ svg sprite가 준비됐다면 아래와 같이 svg url을 입력할 수 있습�
 
 ```jsx
 const player = new BetterPlayer.Player({
-	...,
-	iconUrl: 'path/to/svg-sprite.svg'
+  ...,
+  iconUrl: 'path/to/svg-sprite.svg'
 });
 ```

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -1,0 +1,10 @@
+$color-main: var(--better-player-color-main, #fff);
+$font-size: var(--better-player-font-size, 16px);
+$font-color: var(--better-player-font-color, #fff);
+$controller-background: var(--better-player-controller-background, linear-gradient(transparent, #000));
+$controller-spacing: var(--better-player-controller-spacing, 5px);
+$controller-icon-size: var(--better-player-controller-icon-size, 32px);
+$controller-font-size: var(--better-player-controller-font-size, 15px);
+$controller-color: var(--better-player-controller-color, #fff);
+$error-screen-icon-size: var(--better-player-error-screen-icon-size, 36px);
+$error-screen-icon-color: var(--better-player-error-screen-icon-color, #fff);

--- a/src/components/core/Core.scss
+++ b/src/components/core/Core.scss
@@ -2,4 +2,6 @@
   position: relative;
   width: 100%;
   height: 100%;
+  font-size: $font-size;
+  color: $font-color;
 }

--- a/src/components/no-video/NoVideo.scss
+++ b/src/components/no-video/NoVideo.scss
@@ -10,6 +10,4 @@
   padding: 20px;
 }
 
-.better-player__no-video-message {
-  color: #fff;
-}
+.better-player__no-video-message {}

--- a/src/plugins/controller/Controller.scss
+++ b/src/plugins/controller/Controller.scss
@@ -1,7 +1,7 @@
 %controller-button {
   box-sizing: border-box;
-  width: 32px;
-  height: 32px;
+  width: $controller-icon-size;
+  height: $controller-icon-size;
   padding: 6px;
   border-radius: 7px;
   cursor: pointer;
@@ -11,14 +11,14 @@
   }
 
   & .better-player__icon {
-    fill: #fff;
+    fill: $controller-color;
   }
 }
 
 %controller-time {
-  color: #fff;
-  margin-left: 5px;
-  font-size: 0.9rem;
+  color: $controller-color;
+  margin-right: $controller-spacing;
+  font-size: $controller-font-size;
 }
 
 %controller-bar {
@@ -35,7 +35,7 @@
     width: 13px;
     height: 13px;
     border-radius: 50%;
-    background: #fff;
+    background: $controller-color;
     cursor: pointer;
     margin-top: -4px;
   }
@@ -44,7 +44,7 @@
     width: 13px;
     height: 13px;
     border-radius: 50%;
-    background: #fff;
+    background: $controller-color;
     cursor: pointer;
   }
   
@@ -52,7 +52,7 @@
     width: 13px;
     height: 13px;
     border-radius: 50%;
-    background: #fff;
+    background: $controller-color;
     cursor: pointer;
   }
 
@@ -102,7 +102,7 @@
   position: absolute;
   bottom: 0px;
   width: 100%;
-  background: linear-gradient(transparent, #000);
+  background: $controller-background;
 }
 
 .better-player__controller-top-panel{
@@ -131,6 +131,7 @@
 
 .better-player__play-toggle-button {
   @extend %controller-button;
+  margin-right: $controller-spacing;
 }
 
 .better-player__current-time {
@@ -150,12 +151,11 @@
 .better-player__mute-toggle-button {
   @extend %controller-button;
   padding: 7.5px;
-  margin-left: 5px;
+  margin-right: $controller-spacing;
 }
 
 .better-player__volume-bar {
   @extend %controller-bar;
-  margin-left: 5px;
   width: 100px;
 }
 

--- a/src/plugins/error-screen/ErrorScreen.scss
+++ b/src/plugins/error-screen/ErrorScreen.scss
@@ -17,15 +17,14 @@
 }
 
 .better-player__error-screen-message {
-  color: #fff;
   padding: 20px;
   text-align: center;
 }
 
 .better-player__reload-button {
   box-sizing: border-box;
-  width: 36px;
-  height: 36px;
+  width: $error-screen-icon-size;
+  height: $error-screen-icon-size;
   padding: 8px;
   border-radius: 7px;
   cursor: pointer;
@@ -35,7 +34,7 @@
   }
 
   & .better-player__icon {
-    fill: #fff;
+    fill: $error-screen-icon-color;
     width: 100%;
     height: 100%;
   }

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 
@@ -9,7 +10,20 @@ module.exports = merge(common, {
       ...common.module.rules,
       {
         test: /\.s[ac]ss$/i,
-        use: ['style-loader', 'css-loader', 'sass-loader'],
+        use: [
+          { loader: 'style-loader' },
+          { loader: 'css-loader' },
+          {
+            loader: 'sass-loader',
+            options: {
+              sourceMap: true,
+              additionalData: '@import "variables";',
+              sassOptions: {
+                includePaths: [path.resolve(__dirname, 'src')],
+              },
+            },
+          },
+        ],
       },
     ],
   },

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -18,7 +18,20 @@ const prod = {
       ...common.module.rules,
       {
         test: /\.s[ac]ss$/i,
-        use: [MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader'],
+        use: [
+          { loader: MiniCssExtractPlugin.loader },
+          { loader: 'css-loader' },
+          {
+            loader: 'sass-loader',
+            options: {
+              sourceMap: true,
+              additionalData: '@import "variables";',
+              sassOptions: {
+                includePaths: [path.resolve(__dirname, 'src')],
+              },
+            },
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
# CSS custom properties를 이용한 커스터마이징
CSS custom properties를 이용해 비디오 플레이어의 스타일을 변경할 수 있도록 하였습니다.
## PR 상세
### sass의 variables
sass의 변수 기능을 이용해서 자주 변경될 수 있는 속성들을 src/_variables.scss 파일로 만들었습니다.

### variables를 위한 webpack 설정
웹팩에서 sass 파일을 로드할 때, 로드 된 sass파일은 글로벌 변수를 참조할 수 없습니다. 따라서 webpack 환경 설정 파일의 sass-loader에 옵션을 추가하여 _variables.scss를 상당에 자동 삽입하도록 하였습니다.

```javascript
{
  loader: 'sass-loader',
  options: {
  sourceMap: true,
  additionalData: '@import "variables";',
  sassOptions: {
    includePaths: [path.resolve(__dirname, 'src')],
  },
},
```

### CSS custom properties
비디오 플레이어의 기본 UI 스타일을 변경하기 위해서 CSS custom properties를 사용합니다. 목록은 다음과 같습니다.
| 이름                                      | 설명                          | 기본값                             |
| ----------------------------------------- | ----------------------------- | ---------------------------------- |
| `--better-player-color-main`              | 비디오 플레이어의 메인 색상   | #fff                               |
| `--better-player-font-size`               | 비디오 플레이어의 폰트 사이즈 | 16px                               |
| `--better-player-font-color`              | 비디오 플레이어의 폰트 색상   | #fff                               |
| `--better-player-controller-background`   | 컨트롤러의 배경 색상          | linear-gradient(transparent, #000) |
| `--better-player-controller-spacing`      | 컨트롤러 유닛 간의 간격       | 5px                                |
| `--better-player-controller-icon-size`    | 컨트롤러 아이콘 크기          | 32px                               |
| `--better-player-controller-font-size`    | 컨트롤러 폰트 크기            | 15px                               |
| `--better-player-controller-color`        | 컨트롤러 아이콘 및 폰트 색상  | #fff                               |
| `--better-player-error-screen-icon-size`  | 에러 스크린의 아이콘 크기     | 36px                               |
| `--better-player-error-screen-icon-color` | 에러 스크린의 아이콘 색상     | #fff                               |