### PR TITLE
하위 엘리먼트 탐색 및 캐싱 리팩토링

### DIFF
--- a/src/base/ui-object/UIObject.js
+++ b/src/base/ui-object/UIObject.js
@@ -5,6 +5,7 @@ import {
   createElement,
   removeElement,
   removeEventListener,
+  qs,
 } from '../../utils/element';
 import Events from '../events';
 
@@ -88,7 +89,7 @@ export default class UIObject extends Events {
 
         if (selector) {
           const wrapper = e => {
-            if (!this.el.querySelector(selector).contains(e.target)) return;
+            if (!qs(this.el, selector)?.contains(e.target)) return;
 
             listener.call(this, e);
           };

--- a/src/base/ui-object/UIObject.js
+++ b/src/base/ui-object/UIObject.js
@@ -5,7 +5,7 @@ import {
   createElement,
   removeElement,
   removeEventListener,
-  qs,
+  querySelector,
 } from '../../utils/element';
 import Events from '../events';
 
@@ -89,7 +89,7 @@ export default class UIObject extends Events {
 
         if (selector) {
           const wrapper = e => {
-            if (!qs(this.el, selector)?.contains(e.target)) return;
+            if (!querySelector(this.el, selector)?.contains(e.target)) return;
 
             listener.call(this, e);
           };

--- a/src/plugins/controller/Controller.js
+++ b/src/plugins/controller/Controller.js
@@ -5,7 +5,7 @@ import UIPlugin from '../../base/ui-plugin';
 import {
   addClass,
   appendChild,
-  getElementByClassName,
+  qs,
   innerHTML,
   removeClass,
 } from '../../utils/element';
@@ -20,6 +20,23 @@ import formatTime from '../../utils/time';
  * @extends UIPlugin
  */
 export default class Controller extends UIPlugin {
+  /**
+   * 하위 엘리먼트를 찾는데 사용할 셀렉터의 집합
+   *
+   * @returns {object}
+   */
+  get selectors() {
+    return {
+      playToggleButton: '[data-play-toggle]',
+      muteToggleButton: '[data-mute-toggle]',
+      fullscreenToggleButton: '[data-fullscreen-toggle]',
+      seekBar: '[data-seek-bar]',
+      volumeBar: '[data-volume-bar]',
+      currentTime: '[data-current-time]',
+      duration: '[data-duration]',
+    };
+  }
+
   get attributes() {
     return {
       class: 'better-player__controller',
@@ -27,14 +44,22 @@ export default class Controller extends UIPlugin {
   }
 
   get events() {
+    const {
+      playToggleButton,
+      muteToggleButton,
+      fullscreenToggleButton,
+      seekBar,
+      volumeBar,
+    } = this.selectors;
+
     return {
-      'click .better-player__play-toggle-button': 'togglePlay',
-      'click .better-player__seek-bar': 'seek',
-      'click .better-player__mute-toggle-button': 'toggleMute',
-      'click .better-player__fullscreen-toggle-button': 'toggleFullscreen',
-      'mousedown .better-player__seek-bar': 'startSeekDrag',
-      'input .better-player__seek-bar': 'updateCurrentTime',
-      'input .better-player__volume-bar': 'setVolume',
+      [`click ${playToggleButton}`]: 'togglePlay',
+      [`click ${seekBar}`]: 'seek',
+      [`click ${muteToggleButton}`]: 'toggleMute',
+      [`click ${fullscreenToggleButton}`]: 'toggleFullscreen',
+      [`mousedown ${seekBar}`]: 'startSeekDrag',
+      [`input ${seekBar}`]: 'updateCurrentTime',
+      [`input ${volumeBar}`]: 'setVolume',
     };
   }
 
@@ -267,28 +292,23 @@ export default class Controller extends UIPlugin {
    * 생성된 하위 엘리먼트들을 캐싱한다
    */
   cacheElements() {
-    this.$playToggleButton = getElementByClassName(
-      this.el,
-      'better-player__play-toggle-button'
-    );
-    this.$seekBar = getElementByClassName(this.el, 'better-player__seek-bar');
-    this.$duration = getElementByClassName(this.el, 'better-player__duration');
-    this.$currentTime = getElementByClassName(
-      this.el,
-      'better-player__current-time'
-    );
-    this.$volumeBar = getElementByClassName(
-      this.el,
-      'better-player__volume-bar'
-    );
-    this.$muteToggleButton = getElementByClassName(
-      this.el,
-      'better-player__mute-toggle-button'
-    );
-    this.$fullscreenToggleButton = getElementByClassName(
-      this.el,
-      'better-player__fullscreen-toggle-button'
-    );
+    const {
+      playToggleButton,
+      muteToggleButton,
+      fullscreenToggleButton,
+      seekBar,
+      volumeBar,
+      currentTime,
+      duration,
+    } = this.selectors;
+
+    this.$playToggleButton = qs(this.el, playToggleButton);
+    this.$seekBar = qs(this.el, seekBar);
+    this.$duration = qs(this.el, duration);
+    this.$currentTime = qs(this.el, currentTime);
+    this.$volumeBar = qs(this.el, volumeBar);
+    this.$muteToggleButton = qs(this.el, muteToggleButton);
+    this.$fullscreenToggleButton = qs(this.el, fullscreenToggleButton);
   }
 
   /**

--- a/src/plugins/controller/Controller.test.js
+++ b/src/plugins/controller/Controller.test.js
@@ -73,7 +73,7 @@ it('비디오가 재생되면 playToggleButton의 클래스를 추가한다', ()
   core.video.emit(Events.VIDEO_PLAY);
 
   expect(
-    controller.$playToggleButton.classList.contains(
+    controller.childElements.playToggleButton.classList.contains(
       'better-player__toggle-button--pressed'
     )
   ).toBe(true);
@@ -91,7 +91,7 @@ it('비디오가 일시 정지되면 playToggleButton의 클래스를 삭제한�
 
   // 클래스가 추가됐는지 확인
   expect(
-    controller.$playToggleButton.classList.contains(
+    controller.childElements.playToggleButton.classList.contains(
       'better-player__toggle-button--pressed'
     )
   ).toBe(true);
@@ -101,7 +101,7 @@ it('비디오가 일시 정지되면 playToggleButton의 클래스를 삭제한�
   core.video.emit(Events.VIDEO_PAUSE);
 
   expect(
-    controller.$playToggleButton.classList.contains(
+    controller.childElements.playToggleButton.classList.contains(
       'better-player__toggle-button--pressed'
     )
   ).toBe(false);
@@ -431,7 +431,8 @@ it('비디오 플레이어를 전체 화면으로 전환한다', () => {
   core.requestFullscreen = jest.fn();
   const controller = new Controller(core);
   controller.render();
-  const fullscreenToggleButtonEl = controller.$fullscreenToggleButton;
+  const fullscreenToggleButtonEl =
+    controller.childElements.fullscreenToggleButton;
 
   fullscreenToggleButtonEl.dispatchEvent(new Event('click', { bubbles: true }));
 
@@ -445,7 +446,8 @@ it('비디오 플레이어의 전체 화면을 해제한다', () => {
   core.exitFullscreen = jest.fn();
   const controller = new Controller(core);
   controller.render();
-  const fullscreenToggleButtonEl = controller.$fullscreenToggleButton;
+  const fullscreenToggleButtonEl =
+    controller.childElements.fullscreenToggleButton;
 
   fullscreenToggleButtonEl.dispatchEvent(new Event('click', { bubbles: true }));
 
@@ -460,7 +462,7 @@ it('비디오 플레이어의 전체 화면을 해제한다', () => {
 //     core.isFullscreen = () => true;
 //     const controller = new Controller(core);
 //     controller.render();
-//     const fullscreenToggleButtonEl = controller.$fullscreenToggleButton;
+//     const fullscreenToggleButtonEl = controller.childElements.fullscreenToggleButton;
 
 //     core.emit(Events.CORE_FULLSCREENCHANGE);
 
@@ -477,7 +479,7 @@ it('비디오 플레이어의 전체 화면을 해제한다', () => {
 //     core.isFullscreen = () => false;
 //     const controller = new Controller(core);
 //     controller.render();
-//     const fullscreenToggleButtonEl = controller.$fullscreenToggleButton;
+//     const fullscreenToggleButtonEl = controller.childElements.fullscreenToggleButton;
 
 //     core.emit(Events.CORE_FULLSCREENCHANGE);
 

--- a/src/plugins/controller/template.js
+++ b/src/plugins/controller/template.js
@@ -1,11 +1,11 @@
 export default function template() {
   return `
     <div class="better-player__controller-top-panel">
-      <input type="range" class="better-player__seek-bar" min="0" max="1" value="0" step="any">
+      <input type="range" class="better-player__seek-bar" min="0" max="1" value="0" step="any" data-seek-bar>
     </div>
     <div class="better-player__controller-bottom-panel">
       <div class="better-player__controller-left-panel">
-        <div class="better-player__toggle-button better-player__play-toggle-button">
+        <div class="better-player__toggle-button better-player__play-toggle-button" data-play-toggle>
           <svg class="better-player__toggle-icon--not-pressed better-player__icon">
             <use href="#better-player-play"></use>
           </svg>
@@ -13,9 +13,9 @@ export default function template() {
             <use href="#better-player-pause"></use>
           </svg>
         </div>
-        <div class="better-player__current-time">00:00</div>
-        <div class="better-player__duration">00:00</div>
-        <div class="better-player__toggle-button better-player__mute-toggle-button">
+        <div class="better-player__current-time" data-current-time>00:00</div>
+        <div class="better-player__duration" data-duration>00:00</div>
+        <div class="better-player__toggle-button better-player__mute-toggle-button" data-mute-toggle>
           <svg class="better-player__toggle-icon--not-pressed better-player__icon">
             <use href="#better-player-volume"></use>
           </svg>
@@ -23,10 +23,10 @@ export default function template() {
             <use href="#better-player-mute"></use>
           </svg>
         </div>
-        <input type="range" class="better-player__volume-bar" min="0" max="1" value="1" step="any">
+        <input type="range" class="better-player__volume-bar" min="0" max="1" value="1" step="any" data-volume-bar>
       </div>
       <div class="better-player__controller-right-panel">
-        <div class="better-player__toggle-button better-player__fullscreen-toggle-button">
+        <div class="better-player__toggle-button better-player__fullscreen-toggle-button" data-fullscreen-toggle>
           <svg class="better-player__toggle-icon--not-pressed better-player__icon">
             <use href="#better-player-fullscreen-in"></use>
           </svg>

--- a/src/plugins/error-screen/ErrorScreen.js
+++ b/src/plugins/error-screen/ErrorScreen.js
@@ -25,7 +25,7 @@ export default class ErrorScreen extends UIPlugin {
 
   get events() {
     return {
-      'click .better-player__reload-button': 'reload',
+      'click [data-reload]': 'reload',
     };
   }
 

--- a/src/plugins/error-screen/template.js
+++ b/src/plugins/error-screen/template.js
@@ -12,7 +12,7 @@ export default function template(config) {
       'notFoundVideo',
       config
     )}</div>
-    <div class="better-player__reload-button">
+    <div class="better-player__reload-button" data-reload>
       <svg class="better-player__icon">
         <use href="#better-player-reload"></use>
       </svg>

--- a/src/utils/element.js
+++ b/src/utils/element.js
@@ -1,5 +1,7 @@
 /** @module utils/element */
 
+import { isString } from './type';
+
 /**
  * 태그와 속성(attribute)를 이용해서 엘리먼트를 생성한다.
  *
@@ -146,10 +148,21 @@ export function showElement(element) {
 /**
  * selector를 이용해 엘리먼트를 찾아 반환한다.
  *
+ * @example
+ *
+ *
  * @param {HTMLElement} parent
- * @param {string} selector
+ * @param {string|object} selector 문자열 또는 {element: selector} 형식의 객체
  * @returns {any}
  */
-export function qs(parent, selector) {
-  return parent.querySelector(selector);
+export function querySelector(parent, selector) {
+  if (isString(selector)) return parent.querySelector(selector);
+
+  const elements = {};
+
+  Object.keys(selector).forEach(elementName => {
+    elements[elementName] = parent.querySelector(selector[elementName]);
+  });
+
+  return elements;
 }

--- a/src/utils/element.js
+++ b/src/utils/element.js
@@ -142,3 +142,14 @@ export function hideElement(element) {
 export function showElement(element) {
   element.style.display = '';
 }
+
+/**
+ * selector를 이용해 엘리먼트를 찾아 반환한다.
+ *
+ * @param {HTMLElement} parent
+ * @param {string} selector
+ * @returns {any}
+ */
+export function qs(parent, selector) {
+  return parent.querySelector(selector);
+}

--- a/src/utils/element.test.js
+++ b/src/utils/element.test.js
@@ -9,6 +9,7 @@ import {
   removeEventListener,
   addClass,
   removeClass,
+  querySelector,
 } from './element';
 
 beforeEach(() => {
@@ -229,5 +230,37 @@ describe('removeClass', () => {
 
     expect(el.classList.length).toBe(1);
     expect(el.classList.contains('b-class')).toBe(true);
+  });
+});
+
+describe('querySelector', () => {
+  it('문자열을 이용해 매칭되는 한 엘리먼트를 반환한다', () => {
+    const target = document.createElement('div');
+    target.dataset.test = 'testId';
+    const selector = '[data-test="testId"]';
+
+    document.body.appendChild(target);
+
+    expect(querySelector(document.body, selector)).toBe(target);
+  });
+
+  it('객체를 이용해 매칭되는 엘리먼트의 집합을 반환한다', () => {
+    const target1 = document.createElement('div');
+    target1.dataset.test = 'testId';
+    const target2 = document.createElement('div');
+    target2.className = 'test-class';
+    const selectors = {
+      target1: '[data-test="testId"]',
+      target2: '.test-class',
+    };
+    const elements = {
+      target1,
+      target2,
+    };
+
+    document.body.appendChild(target1);
+    document.body.appendChild(target2);
+
+    expect(querySelector(document.body, selectors)).toEqual(elements);
   });
 });


### PR DESCRIPTION
# 하위 엘리먼트 탐색 및 캐싱 리팩토링
하위 엘리먼트 탐색에 클래스를 의존하지 않도록 변경하였습니다. 또한 캐싱을 위한 유틸을 생성하여 코드의 중복을 방지했습니다.
## PR 상세
### data-attribute 사용
하위 엘리먼트 탐색에 클래스 이름 대신 data-attribute를 사용합니다. 클래스 이름은 스타일과 관련된 로직에만 사용하기로 하고, 엘리먼트 탐색은 쉽게 변하지 않는 data-attribute를 이용하였습니다.
### 중복되는 코드 삭제
**Controller 클래스에 selectors getter 추가**
하위 엘리먼트 캐싱(controller.cacheElements)과 이벤트 델리게이션(controller.events)에 `[data="..."]` 셀렉터가 중복으로 존재합니다. 따라서 selectors라는 getter를 이용하여 중복되는 코드를 삭제하였습니다.

**querySelector 유틸 추가**
Controller 클래스의 cacheElements 메소드가 다음과 같았습니다.
```javascript
cacheElements() {
    this.$playToggleButton = getElementByClassName(this.el, ...);
    this.$seekBar = getElementByClassName(this.el, 'better-player__seek-bar');
    this.$duration = getElementByClassName(this.el, 'better-player__duration');
    this.$currentTime = getElementByClassName(this.el, ...);
    // ...
}
```
getElementByClassName의 중복을 방지하기 위해, 하위 엘리먼트를 탐색해 한 번에 반환하는 querySelector 유틸을 추가하였습니다. 다음과 같이 변경되었습니다.
```javascript
this.childElements = querySelector(this.el, this.selectors);
```