### PR TITLE
ClickToPlay 플러그인 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ const player = new BetterPlayer.Player(options);
 
 비디오 엘리먼트의 높이를 px 단위로 설정합니다. height가 제공되지 않을 경우 부모 엘리먼트의 높이를 따릅니다.
 
+**clickToPlay: boolean**
+
+비디오 클릭으로 영상을 재생합니다. 기본값은 true이며 이 기능을 사용하고 싶지 않을 경우 false를 입력하세요.
+
 **i18n: object**
 
 텍스트의 국제화와 지역화를 위해 사용되는 객체입니다. 자세한 속성 값은 [defaults.js](https://github.com/youngdo212/better-player/blob/develop/src/config/defaults.js)를 참고하세요.

--- a/src/base/events/Events.js
+++ b/src/base/events/Events.js
@@ -197,6 +197,14 @@ Events.VIDEO_SEEKED = 'video:seeked';
 Events.VIDEO_ERROR = 'video:error';
 
 /**
+ * 비디오가 클릭되었을 때 발생하는 이벤트
+ *
+ * @event VIDEO_CLICK
+ * @param {Event} event
+ */
+Events.VIDEO_CLICK = 'video:click';
+
+/**
  * 비디오 플레이어의 전체 화면 여부가 변경되었을 때 발생.
  *
  * @event CORE_FULLSCREENCHANGE

--- a/src/base/plugin/Plugin.js
+++ b/src/base/plugin/Plugin.js
@@ -1,0 +1,72 @@
+/** @module base/plugin */
+
+import Events from '../events';
+
+/**
+ * UI를 가지지 않는 플러그인의 베이스 클래스
+ *
+ * @extends Events
+ */
+export default class Plugin extends Events {
+  /**
+   * 모든 플러그인은 내부에서 core를 갖는다.
+   *
+   * @returns {module:components/core}
+   */
+  get core() {
+    return this._core;
+  }
+
+  /**
+   * core를 통해서 video에 접근할 수 있다.
+   *
+   * @returns {module:base/video}
+   */
+  get video() {
+    return this._core.video;
+  }
+
+  /**
+   * core를 설정하고 이벤트 리스너를 등록한다.
+   * @param {module:components/core} core
+   */
+  constructor(core) {
+    super();
+    this._core = core;
+    this.enabled = true;
+    this.addEventListeners();
+  }
+
+  /**
+   * Core에 이벤트 리스너를 등록한다.
+   * NOTE: disable/enable을 제대로 작동시키기 위해서 반드시 this.listenTo 메소드를 이용해 이벤트 리스너를 등록해야한다.
+   */
+  addEventListeners() {}
+
+  /**
+   * 플러그인을 작동시킨다.
+   * 이 함수는 disable 이후에 다시 플러그인을 작동시킬 때만 사용해야 한다.
+   */
+  enable() {
+    if (this.enabled) return;
+    this.addEventListeners();
+    this.enabled = true;
+  }
+
+  /**
+   * 플러그인을 작동하지 않도록 한다.
+   */
+  disable() {
+    this.stopListening();
+    this.enabled = false;
+  }
+
+  /**
+   * 플러그인을 파괴하여 등록된 이벤트 리스너를 전부 제거한다.
+   */
+  destroy() {
+    this.off();
+    this.stopListening();
+    return this;
+  }
+}

--- a/src/base/plugin/Plugin.test.js
+++ b/src/base/plugin/Plugin.test.js
@@ -1,0 +1,119 @@
+import Core from '../../components/core';
+import Plugin from './Plugin';
+import config from '../../config/defaults';
+
+it('core속성을 가진다', () => {
+  const core = new Core(config);
+  const plugin = new Plugin(core);
+
+  expect(plugin.core).toBe(core);
+});
+
+it('video속성을 가진다', () => {
+  const core = new Core(config);
+  const plugin = new Plugin(core);
+
+  expect(plugin.video).toBe(core.video);
+});
+
+it('enabled 속성을 가지며 기본 값은 true이다', () => {
+  const core = new Core(config);
+  const plugin = new Plugin(core);
+
+  expect(plugin.enabled).toBe(true);
+});
+
+it('인스턴스를 생성하면 이벤트 리스너를 추가한다', () => {
+  class MyPlugin extends Plugin {
+    addEventListeners() {
+      this.listenTo(this.core, eventName, this.handleEvent);
+    }
+    handleEvent() {
+      callback();
+    }
+  }
+  const eventName = 'test';
+  const callback = jest.fn();
+  const core = new Core(config);
+  const myPlugin = new MyPlugin(core); // eslint-disable-line no-unused-vars
+
+  core.emit(eventName);
+
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+it('disable을 통해 플러그인을 사용하지 못하게 만든다', () => {
+  class MyPlugin extends Plugin {
+    addEventListeners() {
+      this.listenTo(this.core, eventName, this.handleEvent);
+    }
+    handleEvent() {
+      callback();
+    }
+  }
+  const eventName = 'test';
+  const callback = jest.fn();
+  const core = new Core(config);
+  const myPlugin = new MyPlugin(core);
+
+  myPlugin.disable();
+  core.emit(eventName);
+
+  expect(callback).toHaveBeenCalledTimes(0);
+});
+
+it('enable을 통해 플러그인을 다시 사용가능하게 만든다', () => {
+  class MyPlugin extends Plugin {
+    addEventListeners() {
+      this.listenTo(this.core, eventName, this.handleEvent);
+    }
+    handleEvent() {
+      callback();
+    }
+  }
+  const eventName = 'test';
+  const callback = jest.fn();
+  const core = new Core(config);
+  const myPlugin = new MyPlugin(core);
+
+  myPlugin.disable();
+  core.emit(eventName);
+
+  expect(callback).toHaveBeenCalledTimes(0);
+
+  myPlugin.enable();
+  core.emit(eventName);
+
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+it('플러그인을 파괴한다', () => {
+  class MyPlugin extends Plugin {
+    addEventListeners() {
+      this.listenTo(this.core, eventName1, this.handleEvent);
+    }
+    handleEvent() {
+      callback1();
+    }
+  }
+  const eventName1 = 'test1';
+  const eventName2 = 'test2';
+  const callback1 = jest.fn();
+  const callback2 = jest.fn();
+  const core = new Core(config);
+  const myPlugin = new MyPlugin(core);
+
+  myPlugin.on(eventName2, callback2);
+  myPlugin.emit(eventName2);
+  core.emit(eventName1);
+
+  expect(callback1).toHaveBeenCalledTimes(1);
+  expect(callback2).toHaveBeenCalledTimes(1);
+
+  myPlugin.destroy();
+  myPlugin.emit(eventName2);
+  core.emit(eventName1);
+
+  expect(callback1).toHaveBeenCalledTimes(1);
+  expect(callback2).toHaveBeenCalledTimes(1);
+});

--- a/src/base/plugin/index.js
+++ b/src/base/plugin/index.js
@@ -1,0 +1,1 @@
+export { default } from './Plugin';

--- a/src/components/core/Core.js
+++ b/src/components/core/Core.js
@@ -9,8 +9,9 @@ import loadSprite from '../../utils/load-sprite';
 import Events from '../../base/events';
 import Fullscreen from '../fullscreen';
 import ErrorScreen from '../../plugins/error-screen';
+import ClickToPlay from '../../plugins/click-to-play';
 
-const plugins = [Controller, ErrorScreen];
+const plugins = [Controller, ErrorScreen, ClickToPlay];
 
 /**
  * 비디오 플레이어의 핵심 클래스
@@ -110,7 +111,7 @@ export default class Core extends UIObject {
   render() {
     this.updateSize();
     appendChild(this.el, this.video.render().el);
-    this.plugins.forEach(plugin => plugin.render());
+    this.plugins.forEach(plugin => plugin.render?.());
     loadSprite(this.config.iconUrl);
 
     if (this.config.parentElement) {

--- a/src/components/html-video/HTMLVideo.js
+++ b/src/components/html-video/HTMLVideo.js
@@ -33,6 +33,7 @@ export default class HTMLVideo extends Video {
       seeking: 'onSeeking',
       seeked: 'onSeeked',
       error: 'onError',
+      click: 'onClick',
     };
   }
 
@@ -134,6 +135,15 @@ export default class HTMLVideo extends Video {
    */
   onError(event) {
     this.emit(Events.VIDEO_ERROR, event);
+  }
+
+  /**
+   * 비디오의 클릭 이벤트를 발생시킨다.
+   *
+   * @param {Event} event
+   */
+  onClick(event) {
+    this.emit(Events.VIDEO_CLICK, event);
   }
 
   /**

--- a/src/components/html-video/HTMLVideo.test.js
+++ b/src/components/html-video/HTMLVideo.test.js
@@ -76,6 +76,16 @@ describe('비디오 이벤트 발생 관련', () => {
 
     expect(callback).toHaveBeenCalled();
   });
+
+  it('비디오 엘리먼트의 click 이벤트가 발생하면 VIDEO_CLICK 이벤트가 발생한다', () => {
+    const video = new HTMLVideo(config);
+    const callback = jest.fn();
+
+    video.on(Events.VIDEO_CLICK, callback);
+    video.el.dispatchEvent(new Event('click'));
+
+    expect(callback).toHaveBeenCalled();
+  });
 });
 
 it('비디오 엘리먼트를 DOM에서 제거하고 src attribute를 초기화한다', () => {

--- a/src/components/player/Player.stories.js
+++ b/src/components/player/Player.stories.js
@@ -112,3 +112,27 @@ InternationalizationException.args = {
   height: 360,
   notFoundVideo: 'video is not found',
 };
+
+/**
+ * 비디오 클릭으로 재생하는 기능을 끈다.
+ *
+ * @param {object} args
+ * @param {boolean} args.clickToPlay
+ */
+export const DisableClickToPlay = ({ clickToPlay }) => {
+  const parent = document.createElement('div');
+
+  new Player({
+    source:
+      'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4',
+    width: 640,
+    height: 360,
+    parent,
+    clickToPlay,
+  });
+
+  return parent;
+};
+DisableClickToPlay.args = {
+  clickToPlay: false,
+};

--- a/src/components/player/Player.stories.js
+++ b/src/components/player/Player.stories.js
@@ -4,7 +4,7 @@ export default {
   title: 'Player',
 };
 
-const Template = ({ source, width, height }) => {
+const Template = ({ source, width, height, clickToPlay = true }) => {
   const parent = document.createElement('div');
 
   new Player({
@@ -12,6 +12,7 @@ const Template = ({ source, width, height }) => {
     parent,
     width,
     height,
+    clickToPlay,
   });
 
   return parent;
@@ -81,6 +82,7 @@ NotFoundVideo.args = {
   source: 'http://localhost/not-found/video.mp4',
   width: 640,
   height: 360,
+  clickToPlay: true,
 };
 
 /**

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -2,6 +2,7 @@ import cloneDeep from 'lodash/cloneDeep';
 
 const defaults = {
   source: { src: '' },
+  clickToPlay: true, // 비디오를 클릭해서 재생 가능하게 하는 기능
   i18n: {
     notSupportVideoFormat:
       '현재 브라우저에서 지원하지 않는 비디오 형식입니다. 다른 브라우저에서 시도하세요.',

--- a/src/plugins/click-to-play/ClickToPlay.js
+++ b/src/plugins/click-to-play/ClickToPlay.js
@@ -20,6 +20,7 @@ export default class ClickToPlay extends Plugin {
       this.disable();
     }
   }
+
   /**
    * 비디오에 클릭 이벤트 리스너를 등록한다.
    */
@@ -37,5 +38,13 @@ export default class ClickToPlay extends Plugin {
     } else {
       this.video.pause();
     }
+  }
+
+  /**
+   * clickToPlay 옵션이 꺼져있을 경우 enable할 수 없다.
+   */
+  enable() {
+    if (!this.core.config.clickToPlay) return;
+    super.enable();
   }
 }

--- a/src/plugins/click-to-play/ClickToPlay.js
+++ b/src/plugins/click-to-play/ClickToPlay.js
@@ -9,14 +9,12 @@ import Plugin from '../../base/plugin';
  * @extends Plugin
  */
 export default class ClickToPlay extends Plugin {
-  constructor(core) {
-    super(core);
-  }
   /**
    * 비디오에 클릭 이벤트 리스너를 등록한다.
    */
   addEventListeners() {
     this.listenTo(this.video, Events.VIDEO_CLICK, this.onClick);
+    this.listenTo(this.video, Events.VIDEO_ERROR, this.disable);
   }
 
   /**

--- a/src/plugins/click-to-play/ClickToPlay.js
+++ b/src/plugins/click-to-play/ClickToPlay.js
@@ -10,6 +10,17 @@ import Plugin from '../../base/plugin';
  */
 export default class ClickToPlay extends Plugin {
   /**
+   * 인스턴스를 생성하고 환경 설정에 clickToPlay 옵션이 false일 경우 비활성화한다.
+   *
+   * @param {module:components/core} core
+   */
+  constructor(core) {
+    super(core);
+    if (!core.config.clickToPlay) {
+      this.disable();
+    }
+  }
+  /**
    * 비디오에 클릭 이벤트 리스너를 등록한다.
    */
   addEventListeners() {

--- a/src/plugins/click-to-play/ClickToPlay.js
+++ b/src/plugins/click-to-play/ClickToPlay.js
@@ -1,0 +1,32 @@
+/** @module plugins/click-to-play */
+
+import Events from '../../base/events';
+import Plugin from '../../base/plugin';
+
+/**
+ * 비디오 클릭으로 재생/일시정지를 할 수 있는 플러그인
+ *
+ * @extends Plugin
+ */
+export default class ClickToPlay extends Plugin {
+  constructor(core) {
+    super(core);
+  }
+  /**
+   * 비디오에 클릭 이벤트 리스너를 등록한다.
+   */
+  addEventListeners() {
+    this.listenTo(this.video, Events.VIDEO_CLICK, this.onClick);
+  }
+
+  /**
+   * 비디오가 재생상태일 경우 일시정지를 하며 일시 정지 상태일 경우 재생한다.
+   */
+  onClick() {
+    if (this.video.isPaused()) {
+      this.video.play();
+    } else {
+      this.video.pause();
+    }
+  }
+}

--- a/src/plugins/click-to-play/ClickToPlay.test.js
+++ b/src/plugins/click-to-play/ClickToPlay.test.js
@@ -95,3 +95,28 @@ it('환경 설정의 clickToPlay가 false인 경우 비활성화한다', () => {
 
   onClickSpy.mockRestore();
 });
+
+it('환경 설정의 clickToPlay가 false인 경우 enable 메소드 호출이 무시된다', () => {
+  const onClickSpy = jest
+    .spyOn(ClickToPlay.prototype, 'onClick')
+    .mockImplementation(() => {});
+  const mockCore = {
+    video: new HTMLVideo(config),
+    config: { ...config, clickToPlay: false },
+  };
+  const clickToPlay = new ClickToPlay(mockCore);
+
+  // enable 전 테스트
+  mockCore.video.emit(Events.VIDEO_CLICK);
+
+  expect(onClickSpy).toHaveBeenCalledTimes(0);
+
+  // enable 후 테스트
+  clickToPlay.enable();
+
+  mockCore.video.emit(Events.VIDEO_CLICK);
+
+  expect(onClickSpy).toHaveBeenCalledTimes(0);
+
+  onClickSpy.mockRestore();
+});

--- a/src/plugins/click-to-play/ClickToPlay.test.js
+++ b/src/plugins/click-to-play/ClickToPlay.test.js
@@ -1,0 +1,55 @@
+import Events from '../../base/events';
+import HTMLVideo from '../../components/html-video';
+import config from '../../config/defaults';
+import ClickToPlay from './ClickToPlay';
+
+it('video 엘리먼트에 클릭이 발생할 경우 onClick 메소드가 호출된다', () => {
+  const onClickSpy = jest
+    .spyOn(ClickToPlay.prototype, 'onClick')
+    .mockImplementation(() => {});
+  const mockCore = {
+    video: new HTMLVideo(config),
+  };
+  const clickToPlay = new ClickToPlay(mockCore); // eslint-disable-line no-unused-vars
+
+  mockCore.video.emit(Events.VIDEO_CLICK);
+
+  expect(onClickSpy).toHaveBeenCalledTimes(1);
+
+  onClickSpy.mockRestore();
+});
+
+it('정지 상태에서 onClick메소드가 호출될 경우 비디오 엘리먼트가 재생된다', () => {
+  HTMLMediaElement.prototype.pause = () => {};
+  const mockCore = {
+    video: new HTMLVideo(config),
+  };
+  const playSpy = jest
+    .spyOn(mockCore.video, 'play')
+    .mockImplementation(() => {});
+  const clickToPlay = new ClickToPlay(mockCore);
+
+  clickToPlay.onClick();
+
+  expect(playSpy).toHaveBeenCalledTimes(1);
+
+  playSpy.mockRestore();
+});
+
+it('재생 상태에서 onClick메소드가 호출될 경우 비디오 엘리먼트가 일시 정지된다', () => {
+  HTMLMediaElement.prototype.pause = () => {};
+  const mockCore = {
+    video: new HTMLVideo(config),
+  };
+  mockCore.video.isPaused = () => false;
+  const pauseSpy = jest
+    .spyOn(mockCore.video, 'pause')
+    .mockImplementation(() => {});
+  const clickToPlay = new ClickToPlay(mockCore);
+
+  clickToPlay.onClick();
+
+  expect(pauseSpy).toHaveBeenCalledTimes(1);
+
+  pauseSpy.mockRestore();
+});

--- a/src/plugins/click-to-play/ClickToPlay.test.js
+++ b/src/plugins/click-to-play/ClickToPlay.test.js
@@ -20,7 +20,6 @@ it('video 엘리먼트에 클릭이 발생할 경우 onClick 메소드가 호출
 });
 
 it('정지 상태에서 onClick메소드가 호출될 경우 비디오 엘리먼트가 재생된다', () => {
-  HTMLMediaElement.prototype.pause = () => {};
   const mockCore = {
     video: new HTMLVideo(config),
   };
@@ -37,7 +36,6 @@ it('정지 상태에서 onClick메소드가 호출될 경우 비디오 엘리먼
 });
 
 it('재생 상태에서 onClick메소드가 호출될 경우 비디오 엘리먼트가 일시 정지된다', () => {
-  HTMLMediaElement.prototype.pause = () => {};
   const mockCore = {
     video: new HTMLVideo(config),
   };
@@ -52,4 +50,27 @@ it('재생 상태에서 onClick메소드가 호출될 경우 비디오 엘리먼
   expect(pauseSpy).toHaveBeenCalledTimes(1);
 
   pauseSpy.mockRestore();
+});
+
+it('비디오에 에러가 발생할 경우 플러그인을 끈다', () => {
+  const onClickSpy = jest
+    .spyOn(ClickToPlay.prototype, 'onClick')
+    .mockImplementation(() => {});
+  const mockCore = {
+    video: new HTMLVideo(config),
+  };
+  const clickToPlay = new ClickToPlay(mockCore); // eslint-disable-line no-unused-vars
+
+  // 에러 발생 전 잘 작동하는지 확인
+  mockCore.video.emit(Events.VIDEO_CLICK);
+
+  expect(onClickSpy).toHaveBeenCalledTimes(1);
+
+  // 비디오 에러 이벤트 발생 후 다시 이벤트 발생
+  mockCore.video.emit(Events.VIDEO_ERROR);
+  mockCore.video.emit(Events.VIDEO_CLICK);
+
+  expect(onClickSpy).toHaveBeenCalledTimes(1);
+
+  onClickSpy.mockRestore();
 });

--- a/src/plugins/click-to-play/ClickToPlay.test.js
+++ b/src/plugins/click-to-play/ClickToPlay.test.js
@@ -9,6 +9,7 @@ it('video 엘리먼트에 클릭이 발생할 경우 onClick 메소드가 호출
     .mockImplementation(() => {});
   const mockCore = {
     video: new HTMLVideo(config),
+    config,
   };
   const clickToPlay = new ClickToPlay(mockCore); // eslint-disable-line no-unused-vars
 
@@ -22,6 +23,7 @@ it('video 엘리먼트에 클릭이 발생할 경우 onClick 메소드가 호출
 it('정지 상태에서 onClick메소드가 호출될 경우 비디오 엘리먼트가 재생된다', () => {
   const mockCore = {
     video: new HTMLVideo(config),
+    config,
   };
   const playSpy = jest
     .spyOn(mockCore.video, 'play')
@@ -38,6 +40,7 @@ it('정지 상태에서 onClick메소드가 호출될 경우 비디오 엘리먼
 it('재생 상태에서 onClick메소드가 호출될 경우 비디오 엘리먼트가 일시 정지된다', () => {
   const mockCore = {
     video: new HTMLVideo(config),
+    config,
   };
   mockCore.video.isPaused = () => false;
   const pauseSpy = jest
@@ -58,6 +61,7 @@ it('비디오에 에러가 발생할 경우 플러그인을 끈다', () => {
     .mockImplementation(() => {});
   const mockCore = {
     video: new HTMLVideo(config),
+    config,
   };
   const clickToPlay = new ClickToPlay(mockCore); // eslint-disable-line no-unused-vars
 
@@ -71,6 +75,23 @@ it('비디오에 에러가 발생할 경우 플러그인을 끈다', () => {
   mockCore.video.emit(Events.VIDEO_CLICK);
 
   expect(onClickSpy).toHaveBeenCalledTimes(1);
+
+  onClickSpy.mockRestore();
+});
+
+it('환경 설정의 clickToPlay가 false인 경우 비활성화한다', () => {
+  const onClickSpy = jest
+    .spyOn(ClickToPlay.prototype, 'onClick')
+    .mockImplementation(() => {});
+  const mockCore = {
+    video: new HTMLVideo(config),
+    config: { ...config, clickToPlay: false },
+  };
+  const clickToPlay = new ClickToPlay(mockCore); // eslint-disable-line no-unused-vars
+
+  mockCore.video.emit(Events.VIDEO_CLICK);
+
+  expect(onClickSpy).toHaveBeenCalledTimes(0);
 
   onClickSpy.mockRestore();
 });

--- a/src/plugins/click-to-play/index.js
+++ b/src/plugins/click-to-play/index.js
@@ -1,0 +1,1 @@
+export { default } from './ClickToPlay';


### PR DESCRIPTION
# ClickToPlay 플러그인 추가
컨트롤러에 접근할 필요 없이 비디오 클릭으로 재생/일시정지 를 수행하는 플러그인을 개발하였습니다.
## PR 상세
### Plugin 클래스 추가
ClickToPlay는 UI를 가지지 않습니다. 따라서 UIPlugin 클래스를 상속하는 대신 Plugin 베이스 클래스를 별도로 만들어 이걸 상속하도록 합니다. Plugin 클래스는 UIPlugin클래스와는 다르게 UI와 관련된 속성 및 메소드(el, render 등)을 가지지 않습니다.
### ClickToPlay 플러그인 추가
비디오의 클릭만으로 재생/일시정지가 가능한 플러그인을 추가하였습니다. 
### click to play 기능을 옵션을 통해 껐다 켰다 할 수 있도록 변경
ClickToPlay 플러그인을 옵션으로 사용하도록 하였습니다. 사용자는 옵션 객체의 clickToPlay 속성을 이용해 이 기능을 사용하지 않을 수도 있습니다. 기본값은 true입니다.
```javascript
const player = new BetterPlayer.Player({
  // ...
  clickToPlay: false,
});
```