### PR TITLE
키보드 플러그인 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ const player = new BetterPlayer.Player(options);
 
 비디오 클릭으로 영상을 재생합니다. 기본값은 true이며 이 기능을 사용하고 싶지 않을 경우 false를 입력하세요.
 
+**keyboard: boolean**
+
+키보드 단축키를 사용할 지 결정합니다. 기본 값은 true입니다
+
 **seekTime: number**
 
 되감기나 앞으로감기 시 이동할 초 단위의 값. 기본값은 5 입니다.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ const player = new BetterPlayer.Player(options);
 
 비디오 클릭으로 영상을 재생합니다. 기본값은 true이며 이 기능을 사용하고 싶지 않을 경우 false를 입력하세요.
 
+**seekTime: number**
+
+되감기나 앞으로감기 시 이동할 초 단위의 값. 기본값은 5 입니다.
+
+**volumeStep: number**
+
+키보드 단축키로 볼륨을 조절할 시 이동할 볼륨 단계. 0 이상 1 이하의 값이며, 기본 값은 0.1 입니다.
+
 **i18n: object**
 
 텍스트의 국제화와 지역화를 위해 사용되는 객체입니다. 자세한 속성 값은 [defaults.js](https://github.com/youngdo212/better-player/blob/develop/src/config/defaults.js)를 참고하세요.

--- a/src/base/events/Events.js
+++ b/src/base/events/Events.js
@@ -213,6 +213,14 @@ Events.VIDEO_CLICK = 'video:click';
 Events.CORE_FULLSCREENCHANGE = 'core:fullsceenchange';
 
 /**
+ * 비디오 플레이어에서 키보드가 눌렸을 때 발생
+ *
+ * @event CORE_KEYDOWN
+ * @param {Event} event
+ */
+Events.CORE_KEYDOWN = 'core:keydown';
+
+/**
  * 페이지의 전체 화면 여부가 변경되었을 때 발생.
  *
  * @event FULLSCREEN_CHANGE

--- a/src/components/core/Core.js
+++ b/src/components/core/Core.js
@@ -10,8 +10,9 @@ import Events from '../../base/events';
 import Fullscreen from '../fullscreen';
 import ErrorScreen from '../../plugins/error-screen';
 import ClickToPlay from '../../plugins/click-to-play';
+import Keyboard from '../../plugins/keyboard';
 
-const plugins = [Controller, ErrorScreen, ClickToPlay];
+const plugins = [Controller, ErrorScreen, ClickToPlay, Keyboard];
 
 /**
  * 비디오 플레이어의 핵심 클래스
@@ -24,6 +25,13 @@ export default class Core extends UIObject {
   get attributes() {
     return {
       class: 'better-player',
+      tabindex: '-1',
+    };
+  }
+
+  get events() {
+    return {
+      keydown: 'onKeydown',
     };
   }
 
@@ -56,11 +64,21 @@ export default class Core extends UIObject {
   }
 
   /**
+   * 전체화면 변경 이벤트를 발생시킨다.
    *
    * @param {Event} event
    */
   onFullscreenChange(event) {
     this.emit(Events.CORE_FULLSCREENCHANGE, event);
+  }
+
+  /**
+   * 키보드 누름 이벤트를 발생시킨다.
+   *
+   * @param {Event} event
+   */
+  onKeydown(event) {
+    this.emit(Events.CORE_KEYDOWN, event);
   }
 
   /**

--- a/src/components/core/Core.js
+++ b/src/components/core/Core.js
@@ -45,6 +45,8 @@ export default class Core extends UIObject {
    * @param {number=} config.width
    * @param {number=} config.height
    * @param {string} config.iconUrl
+   * @param {boolean} config.clickToPlay
+   * @param {boolean} config.keyboard
    */
   constructor(config) {
     super();

--- a/src/components/core/Core.scss
+++ b/src/components/core/Core.scss
@@ -4,4 +4,5 @@
   height: 100%;
   font-size: $font-size;
   color: $font-color;
+  outline: none;
 }

--- a/src/components/core/Core.test.js
+++ b/src/components/core/Core.test.js
@@ -279,3 +279,14 @@ it('리로드할 경우 video의 reload 함수를 호출하고 모든 플러그�
     core.plugins.length
   );
 });
+
+it('엘리먼트에 keydown 이벤트가 발생할 경우 CORE_KEYDOWN 이벤트를 적절한 인자와 함께 발생시킨다', () => {
+  const callback = jest.fn();
+  const core = new Core(config);
+  core.on(Events.CORE_KEYDOWN, callback);
+
+  core.el.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true }));
+
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback.mock.calls[0][0]).toBeDefined();
+});

--- a/src/components/html-video/HTMLVideo.js
+++ b/src/components/html-video/HTMLVideo.js
@@ -202,6 +202,7 @@ export default class HTMLVideo extends Video {
    */
   seek(time) {
     if (time < 0) time = 0;
+    if (time > this.getDuration()) time = this.getDuration();
     this.el.currentTime = time;
   }
 
@@ -210,6 +211,8 @@ export default class HTMLVideo extends Video {
    * @param {number} volume
    */
   setVolume(volume) {
+    if (volume < 0) volume = 0;
+    if (volume > 1) volume = 1;
     this.lastVolume = volume;
     this.el.volume = volume;
   }

--- a/src/components/html-video/HTMLVideo.test.js
+++ b/src/components/html-video/HTMLVideo.test.js
@@ -146,6 +146,15 @@ it('비디오의 현재 시간을 음수로 변경하면 영상의 처음으로 
   expect(video.getCurrentTime()).toBe(0);
 });
 
+it('비디오의 현재 시간은 총 길이보다 크게 설정하면 총 길이로 설정된다', () => {
+  const video = new HTMLVideo(config);
+  video.getDuration = () => 200;
+
+  video.seek(1000);
+
+  expect(video.el.currentTime).toBe(200);
+});
+
 it('비디오 엘리먼트의 durationchange 이벤트가 발생하면 VIDEO_DURATIONCHANGE 이벤트가 발생한다', () => {
   const video = new HTMLVideo(config);
   const callback = jest.fn();
@@ -162,6 +171,22 @@ it('비디오의 볼륨을 조절한다', () => {
   video.setVolume(0.7);
 
   expect(video.getVolume()).toBe(0.7);
+});
+
+it('비디오의 볼륨을 음수로 설정하면 0으로 설정된다', () => {
+  const video = new HTMLVideo(config);
+
+  video.setVolume(-1);
+
+  expect(video.getVolume()).toBe(0);
+});
+
+it('비디오의 볼륨을 1보다 큰 값으로 설정하면 1로 설정된다', () => {
+  const video = new HTMLVideo(config);
+
+  video.setVolume(2);
+
+  expect(video.getVolume()).toBe(1);
 });
 
 it('비디오 엘리먼트의 volumechange 이벤트가 발생하면 VIDEO_VOLUMECHANGE 이벤트가 발생한다', () => {

--- a/src/components/player/Player.stories.js
+++ b/src/components/player/Player.stories.js
@@ -142,7 +142,7 @@ DisableClickToPlay.args = {
 /**
  * 키보드와 관련된 옵션 변경을 위한 스토리
  */
-export const KeyboardShortcut = ({ seekTime, volumeStep }) => {
+export const KeyboardShortcut = ({ seekTime, volumeStep, keyboard }) => {
   const parent = document.createElement('div');
 
   new Player({
@@ -153,6 +153,7 @@ export const KeyboardShortcut = ({ seekTime, volumeStep }) => {
     parent,
     seekTime,
     volumeStep,
+    keyboard,
   });
 
   return parent;
@@ -160,4 +161,5 @@ export const KeyboardShortcut = ({ seekTime, volumeStep }) => {
 KeyboardShortcut.args = {
   seekTime: 5,
   volumeStep: 0.1,
+  keyboard: true,
 };

--- a/src/components/player/Player.stories.js
+++ b/src/components/player/Player.stories.js
@@ -138,3 +138,26 @@ export const DisableClickToPlay = ({ clickToPlay }) => {
 DisableClickToPlay.args = {
   clickToPlay: false,
 };
+
+/**
+ * 키보드와 관련된 옵션 변경을 위한 스토리
+ */
+export const KeyboardShortcut = ({ seekTime, volumeStep }) => {
+  const parent = document.createElement('div');
+
+  new Player({
+    source:
+      'https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-576p.mp4',
+    width: 640,
+    height: 360,
+    parent,
+    seekTime,
+    volumeStep,
+  });
+
+  return parent;
+};
+KeyboardShortcut.args = {
+  seekTime: 5,
+  volumeStep: 0.1,
+};

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -3,6 +3,8 @@ import cloneDeep from 'lodash/cloneDeep';
 const defaults = {
   source: { src: '' },
   clickToPlay: true, // 비디오를 클릭해서 재생 가능하게 하는 기능
+  seekTime: 5, // 앞으로 가기나 뒤로 가기 시 이동할 초 단위
+  volumeStep: 0.1, // 키보드 단축키로 이동할 볼륨 단계
   i18n: {
     notSupportVideoFormat:
       '현재 브라우저에서 지원하지 않는 비디오 형식입니다. 다른 브라우저에서 시도하세요.',

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -3,6 +3,7 @@ import cloneDeep from 'lodash/cloneDeep';
 const defaults = {
   source: { src: '' },
   clickToPlay: true, // 비디오를 클릭해서 재생 가능하게 하는 기능
+  keyboard: true,
   seekTime: 5, // 앞으로 가기나 뒤로 가기 시 이동할 초 단위
   volumeStep: 0.1, // 키보드 단축키로 이동할 볼륨 단계
   i18n: {

--- a/src/plugins/keyboard/Keyboard.js
+++ b/src/plugins/keyboard/Keyboard.js
@@ -1,0 +1,91 @@
+/** @module plugins/keyboard */
+
+import Events from '../../base/events';
+import Plugin from '../../base/plugin';
+
+/**
+ * 비디오 플레이어의 키보드 단축키를 제공하는 플러그인
+ *
+ * @extends Plugin
+ */
+export default class Keyboard extends Plugin {
+  /**
+   * 인스턴스를 생성하고 keyAction 매핑 객체를 속성으로 추가한다.
+   *
+   * @param {module:components/core} core
+   */
+  constructor(core) {
+    super(core);
+    this.keyAction = {
+      [keyMap['left']]: this.pressLeft.bind(this),
+      [keyMap['right']]: this.pressRight.bind(this),
+      [keyMap['up']]: this.pressUp.bind(this),
+      [keyMap['down']]: this.pressDown.bind(this),
+      [keyMap['space']]: this.pressSpaceBar.bind(this),
+    };
+  }
+
+  /**
+   * 이벤트 리스너를 등록한다.
+   */
+  addEventListeners() {
+    this.listenTo(this.core, Events.CORE_KEYDOWN, this.onKeydown);
+    this.listenTo(this.video, Events.VIDEO_ERROR, this.disable);
+  }
+
+  /**
+   * 키보드 이벤트를 처리한다.
+   *
+   * @param {KeyboardEvent} event
+   */
+  onKeydown(event) {
+    event.preventDefault();
+    this.keyAction[event.key]?.();
+  }
+
+  /**
+   * 앞으로 감기를 수행한다.
+   */
+  pressRight() {
+    this.video.seek(this.video.getCurrentTime() + this.core.config.seekTime);
+  }
+
+  /**
+   * 되감기를 수행한다.
+   */
+  pressLeft() {
+    this.video.seek(this.video.getCurrentTime() - this.core.config.seekTime);
+  }
+
+  /**
+   * 볼륨을 높인다
+   */
+  pressUp() {
+    this.video.setVolume(this.video.getVolume() + this.core.config.volumeStep);
+  }
+
+  /**
+   * 볼륨을 낮춘다
+   */
+  pressDown() {
+    this.video.setVolume(this.video.getVolume() - this.core.config.volumeStep);
+  }
+
+  /**
+   * 비디오가 재생 상태일 경우 일시정지를, 일시 정지 상태일 경우 재생을 한다.
+   */
+  pressSpaceBar() {
+    this.video.isPaused() ? this.video.play() : this.video.pause();
+  }
+}
+
+/**
+ * key(식별자) : value(`KeyboardEvent.key`) 로 이루어진 맵핑 객체
+ */
+const keyMap = {
+  left: 'ArrowLeft',
+  right: 'ArrowRight',
+  up: 'ArrowUp',
+  down: 'ArrowDown',
+  space: ' ',
+};

--- a/src/plugins/keyboard/Keyboard.js
+++ b/src/plugins/keyboard/Keyboard.js
@@ -11,6 +11,7 @@ import Plugin from '../../base/plugin';
 export default class Keyboard extends Plugin {
   /**
    * 인스턴스를 생성하고 keyAction 매핑 객체를 속성으로 추가한다.
+   * 키보드를 사용하지 않는 옵션을 줄 경우 disable을 한다.
    *
    * @param {module:components/core} core
    */
@@ -23,6 +24,7 @@ export default class Keyboard extends Plugin {
       [keyMap['down']]: this.pressDown.bind(this),
       [keyMap['space']]: this.pressSpaceBar.bind(this),
     };
+    if (!core.config.keyboard) this.disable();
   }
 
   /**
@@ -76,6 +78,14 @@ export default class Keyboard extends Plugin {
    */
   pressSpaceBar() {
     this.video.isPaused() ? this.video.play() : this.video.pause();
+  }
+
+  /**
+   * 키보드 플러그인을 킨다. 키보드를 사용하지 않는 설정인 경우 키지 않는다.
+   */
+  enable() {
+    if (!this.core.config.keyboard) return;
+    super.enable();
   }
 }
 

--- a/src/plugins/keyboard/Keyboard.test.js
+++ b/src/plugins/keyboard/Keyboard.test.js
@@ -1,0 +1,123 @@
+import Events from '../../base/events';
+import Core from '../../components/core';
+import config from '../../config/defaults';
+import Keyboard from './Keyboard';
+
+it('코어에 CORE_KEYDOWN 이벤트가 발생하면 onKeydown 메소드가 호출된다', () => {
+  const onKeydownSpy = jest
+    .spyOn(Keyboard.prototype, 'onKeydown')
+    .mockImplementation(() => {});
+  const core = new Core(config);
+
+  core.emit(Events.CORE_KEYDOWN, new KeyboardEvent('keydown'));
+
+  expect(onKeydownSpy).toHaveBeenCalledTimes(1);
+
+  onKeydownSpy.mockRestore();
+});
+
+it('왼쪽 방향키 버튼 이벤트가 발생하면 비디오를 되감는다', () => {
+  const core = new Core(config);
+  const video = core.video;
+  const seekSpy = jest.spyOn(video, 'seek');
+  const keyboardPlugin = new Keyboard(core);
+  const answer = video.getCurrentTime() - config.seekTime;
+
+  keyboardPlugin.onKeydown(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+
+  expect(seekSpy).toHaveBeenCalledWith(answer);
+
+  seekSpy.mockRestore();
+});
+
+it('오른쪽 방향키 버튼 이벤트가 발생하면 비디오를 앞으로 감는다', () => {
+  const core = new Core(config);
+  const video = core.video;
+  const seekSpy = jest.spyOn(video, 'seek');
+  const keyboardPlugin = new Keyboard(core);
+  const answer = video.getCurrentTime() + config.seekTime;
+
+  keyboardPlugin.onKeydown(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+
+  expect(seekSpy).toHaveBeenCalledWith(answer);
+
+  seekSpy.mockRestore();
+});
+
+it('위쪽 방향키 버튼 이벤트가 발생하면 비디오의 볼륨을 키운다', () => {
+  const core = new Core(config);
+  const video = core.video;
+  video.getVolume = () => 1;
+  const setVolumeSpy = jest.spyOn(video, 'setVolume');
+  const keyboardPlugin = new Keyboard(core);
+  const answer = video.getVolume() + config.volumeStep;
+
+  keyboardPlugin.onKeydown(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+
+  expect(setVolumeSpy).toHaveBeenCalledWith(answer);
+
+  setVolumeSpy.mockRestore();
+});
+
+it('아래쪽 방향키 버튼 이벤트가 발생하면 비디오의 볼륨을 낮춘다', () => {
+  const core = new Core(config);
+  const video = core.video;
+  video.getVolume = () => 1;
+  const setVolumeSpy = jest.spyOn(video, 'setVolume');
+  const keyboardPlugin = new Keyboard(core);
+  const answer = video.getVolume() - config.volumeStep;
+
+  keyboardPlugin.onKeydown(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+
+  expect(setVolumeSpy).toHaveBeenCalledWith(answer);
+
+  setVolumeSpy.mockRestore();
+});
+
+it('일시 정지 중 스페이스바 버튼 이벤트가 발생하면 비디오를 재생 시킨다', () => {
+  const core = new Core(config);
+  const video = core.video;
+  const playSpy = jest.spyOn(video, 'play').mockImplementation(() => {});
+  const keyboardPlugin = new Keyboard(core);
+
+  keyboardPlugin.onKeydown(new KeyboardEvent('keydown', { key: ' ' }));
+
+  expect(playSpy).toHaveBeenCalledTimes(1);
+
+  playSpy.mockRestore();
+});
+
+it('재생 중 스페이스바 버튼 이벤트가 발생하면 비디오를 일시 정지 시킨다', () => {
+  const core = new Core(config);
+  const video = core.video;
+  video.isPaused = () => false;
+  const pauseSpy = jest.spyOn(video, 'pause').mockImplementation(() => {});
+  const keyboardPlugin = new Keyboard(core);
+
+  keyboardPlugin.onKeydown(new KeyboardEvent('keydown', { key: ' ' }));
+
+  expect(pauseSpy).toHaveBeenCalledTimes(1);
+
+  pauseSpy.mockRestore();
+});
+
+it('등록되지 않은 키보드 이벤트가 발생하는 경우 에러가 발생하지 않는다', () => {
+  const core = new Core(config);
+  const keyboardPlugin = new Keyboard(core);
+
+  keyboardPlugin.onKeydown(new KeyboardEvent('keydown', { key: 'Shift' }));
+});
+
+it('비디오에서 에러 이벤트가 발생하면 disable이 호출된다', () => {
+  const disableSpy = jest
+    .spyOn(Keyboard.prototype, 'disable')
+    .mockImplementation(() => {});
+  const core = new Core(config);
+  const video = core.video;
+
+  video.emit(Events.VIDEO_ERROR);
+
+  expect(disableSpy).toHaveBeenCalledTimes(1);
+
+  disableSpy.mockRestore();
+});

--- a/src/plugins/keyboard/Keyboard.test.js
+++ b/src/plugins/keyboard/Keyboard.test.js
@@ -121,3 +121,32 @@ it('비디오에서 에러 이벤트가 발생하면 disable이 호출된다', (
 
   disableSpy.mockRestore();
 });
+
+it('config에 keyboard값이 false이면 disable이 호출된다', () => {
+  const disableSpy = jest
+    .spyOn(Keyboard.prototype, 'disable')
+    .mockImplementation(() => {});
+  // eslint-disable-next-line no-unused-vars
+  const core = new Core({
+    ...config,
+    keyboard: false,
+  });
+
+  expect(disableSpy).toHaveBeenCalledTimes(1);
+
+  disableSpy.mockRestore();
+});
+
+it('config에 keyboard값이 false이면 enable이 동작하지 않는다', () => {
+  const core = new Core({
+    ...config,
+    keyboard: false,
+  });
+  const keyboardPlugin = new Keyboard(core);
+
+  expect(keyboardPlugin.enabled).toBe(false);
+
+  keyboardPlugin.enable();
+
+  expect(keyboardPlugin.enabled).toBe(false);
+});

--- a/src/plugins/keyboard/index.js
+++ b/src/plugins/keyboard/index.js
@@ -1,0 +1,1 @@
+export { default } from './Keyboard';


### PR DESCRIPTION
# 요약
키보드 기능을 지원하는 플러그인을 추가하였습니다

## PR 상세
키보드 단축키를 지원합니다. 키보드 기능을 위해서는 비디오 플레이어를 클릭하여 포커싱을 한 상태여야 합니다. 비디오 플레이어의 바깥을 클릭하면 키보드 단축키가 동작하지 않습니다.

매핑 된 키보드 단축키는 다음과 같습니다.
| 키 | 동작 |
|-------|-------|
| 화살표 왼쪽 | 영상을 뒤로 되돌립니다 |
| 화살표 오른쪽 | 영상을 앞으로 이동합니다 |
| 화살표 위 | 볼륨을 높입니다 |
| 화살표 아래 | 볼륨을 낮춥니다 |
| 스페이스바 | 비디오를 재생 또는 일시 정지 시킵니다 |

### 옵션을 통해 끄고 킬 수 있다
키보드 플러그인은 옵션 객체의 keyboard 속성을 통해 끌 수 있습니다. 기본 값은 true로서 키보드 단축키가 작동하는 상태입니다.
```js
const player = BetterPlayer.Player({
  keyboard: false,
})
```

### 시간 및 볼륨 이동 범위 환경 설정 가능
키보드로 얼마나 변경할 지 정도를 결정하는 옵션이 추가되었습니다. seekTime과 volumeStep은 각각 시간 탐색 범위와 볼륨 변경 단계를 나타냅니다. 기본 값은 seekTime은 5, volumeStep은 0.1입니다.
```js
const player = BetterPlayer.Player({
  seekTime: 10,
  volumeStep: 0.2,
})
```

### 비디오 플레이어에 포커싱 시 기본 이벤트 동작 방어
키보드 비디오를 클릭으로 포커싱을 한 후 키보드 누르면 기본 동작이 전부 방어됩니다. 예를 들어 위아래 키보드를 눌러도 문서의 스크롤이 위아래로 이동하지 않으며, 비디오 플레이어의 모든 range input에 대해 thumb이 동작하지 않도록 합니다.